### PR TITLE
fix waiting for input when run through launcher + added some config options

### DIFF
--- a/buku_run
+++ b/buku_run
@@ -10,6 +10,7 @@ new_bookmark="Alt+n"
 actions="Alt+a"
 edit="Alt+e"
 delete="Alt+d"
+copyurl="Alt+l"
 
 # colors
 help_color="#334433"
@@ -44,9 +45,9 @@ main () {
 Use <span color='${help_color}'>${switch_view}</span> to switch View. <span color='${help_color}'>${actions}</span> for actions"
     if [[ $mode == "bookmarks" ]]; then
         content=$(buku -p -f 2 --tacit | grep -v 'waiting for input'| awk 'NF == 2 { $0 = $0 "NOTAG" }; { $2 = substr($2,0,80); print $1"\t"$2"\t"$3,$4,$5 }' | column -t -s $'\t')
-        menu=$(echo "${content}" | _rofi -p '> ' -filter "${filter}" -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
+        menu=$(echo "${content}" | _rofi -p '> ' -filter "${filter}" -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}" -kb-custom-6 "${copyurl}")
     elif [[ $mode == "tags" ]]; then
-        menu=$(buku --np --st | awk '{$NF=""; print $0}' | cut -d ' ' -f2-  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
+        menu=$(buku --np --st | awk '{$NF=""; print $0}' | cut -d ' ' -f2-  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}" -kb-custom-6 "${copyurl}")
     fi
     val=$?
     if [[ $val -eq 1 ]]; then
@@ -59,6 +60,9 @@ Use <span color='${help_color}'>${switch_view}</span> to switch View. <span colo
         deleteMenu
     elif [[ $val -eq 13 ]]; then
         editMenu
+    elif [[ $val -eq 15 ]]; then
+        urlcopy=$(echo "${menu}" | awk '{ print $2 }')
+	echo "${urlcopy}" | xclip -selection clipboard
     elif [[ $val -eq 11 ]]; then
         if [[ $mode == "bookmarks" ]]; then
             export mode="tags"

--- a/buku_run
+++ b/buku_run
@@ -14,6 +14,7 @@ copyurl="Alt+l"
 
 #libnotify messages
 notifysend='true'
+reverselist='false'
 
 # colors
 help_color="#334433"
@@ -47,7 +48,11 @@ main () {
     HELP="Welcome to Buku. Use <span color='${help_color}'>${new_bookmark}</span> to add a new Bookmark
 Use <span color='${help_color}'>${switch_view}</span> to switch View. <span color='${help_color}'>${actions}</span> for actions"
     if [[ $mode == "bookmarks" ]]; then
-        content=$(buku -p -f 2 --tacit | grep -v 'waiting for input'| awk 'NF == 2 { $0 = $0 "NOTAG" }; { $2 = substr($2,0,80); print $1"\t"$2"\t"$3,$4,$5 }' | column -t -s $'\t')
+	    if [[ $reverselist == "true" ]] ; then
+		content=$(buku -p -f 2 | grep -v 'waiting for input'| sort -V -r | awk 'NF == 2 { $0 = $0 "NOTAG" }; { $2 = substr($2,0,80); print $1"\t"$2"\t"$3,$4,$5 }' | column -t -s $'\t')
+	    else
+        	content=$(buku -p -f 2 | grep -v 'waiting for input'| awk 'NF == 2 { $0 = $0 "NOTAG" }; { $2 = substr($2,0,80); print $1"\t"$2"\t"$3,$4,$5 }' | column -t -s $'\t')
+	    fi
         menu=$(echo "${content}" | _rofi -p '> ' -filter "${filter}" -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}" -kb-custom-6 "${copyurl}")
     elif [[ $mode == "tags" ]]; then
         menu=$(buku --np --st | awk '{$NF=""; print $0}' | cut -d ' ' -f2-  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}" -kb-custom-6 "${copyurl}")
@@ -81,11 +86,11 @@ Use <span color='${help_color}'>${switch_view}</span> to switch View. <span colo
         if [[ $mode == "bookmarks" ]]; then
             id=$(echo "${menu%% *}")
             for bm in ${id}; do
-                buku -o "${bm}"
 	        if [[ $notifysend == "true" ]] ; then
 		    url=$(echo "${menu}" | awk '{ print $2 }')
 		    notify-send "Opening ${url}"
 		fi
+                buku -o "${bm}"
             done
         elif [[ $mode == "tags" ]]; then
             filter="${menu}" mode="bookmarks" main

--- a/buku_run
+++ b/buku_run
@@ -12,6 +12,9 @@ edit="Alt+e"
 delete="Alt+d"
 copyurl="Alt+l"
 
+#libnotify messages
+notifysend='true'
+
 # colors
 help_color="#334433"
 
@@ -61,8 +64,11 @@ Use <span color='${help_color}'>${switch_view}</span> to switch View. <span colo
     elif [[ $val -eq 13 ]]; then
         editMenu
     elif [[ $val -eq 15 ]]; then
-        urlcopy=$(echo "${menu}" | awk '{ print $2 }')
-	echo "${urlcopy}" | xclip -selection clipboard
+        url=$(echo "${menu}" | awk '{ print $2 }')
+	echo "${url}" | xclip -selection clipboard
+	if [[ $notifysend == "true" ]] ; then
+	    notify-send "Copied ${url}"
+        fi
     elif [[ $val -eq 11 ]]; then
         if [[ $mode == "bookmarks" ]]; then
             export mode="tags"
@@ -76,6 +82,10 @@ Use <span color='${help_color}'>${switch_view}</span> to switch View. <span colo
             id=$(echo "${menu%% *}")
             for bm in ${id}; do
                 buku -o "${bm}"
+	        if [[ $notifysend == "true" ]] ; then
+		    url=$(echo "${menu}" | awk '{ print $2 }')
+		    notify-send "Opening ${url}"
+		fi
             done
         elif [[ $mode == "tags" ]]; then
             filter="${menu}" mode="bookmarks" main

--- a/buku_run
+++ b/buku_run
@@ -43,7 +43,7 @@ main () {
     HELP="Welcome to Buku. Use <span color='${help_color}'>${new_bookmark}</span> to add a new Bookmark
 Use <span color='${help_color}'>${switch_view}</span> to switch View. <span color='${help_color}'>${actions}</span> for actions"
     if [[ $mode == "bookmarks" ]]; then
-        content=$(buku -p -f 2 | awk 'NF == 2 { $0 = $0 "NOTAG" }; { $2 = substr($2,0,80); print $1"\t"$2"\t"$3,$4,$5 }' | column -t -s $'\t')
+        content=$(buku -p -f 2 --tacit | grep -v 'waiting for input'| awk 'NF == 2 { $0 = $0 "NOTAG" }; { $2 = substr($2,0,80); print $1"\t"$2"\t"$3,$4,$5 }' | column -t -s $'\t')
         menu=$(echo "${content}" | _rofi -p '> ' -filter "${filter}" -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
     elif [[ $mode == "tags" ]]; then
         menu=$(buku --np --st | awk '{$NF=""; print $0}' | cut -d ' ' -f2-  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")

--- a/config.buku
+++ b/config.buku
@@ -12,5 +12,8 @@ edit="Alt+e"
 delete="Alt+d"
 copyurl="Alt+l"
 
+#libnotify messages
+notifysend='true'
+
 # colors
 help_color="#2d7ed8"

--- a/config.buku
+++ b/config.buku
@@ -10,6 +10,7 @@ new_bookmark="Alt+n"
 actions="Alt+a"
 edit="Alt+e"
 delete="Alt+d"
+copyurl="Alt+l"
 
 # colors
 help_color="#2d7ed8"

--- a/config.buku
+++ b/config.buku
@@ -14,6 +14,8 @@ copyurl="Alt+l"
 
 #libnotify messages
 notifysend='true'
+#display oldest bookmarks on top by default
+reverselist='false'
 
 # colors
 help_color="#2d7ed8"


### PR DESCRIPTION
I was getting some weird message from buku when starting buku_run through rofi instance
![2018-06-05-114525_866x453_scrot](https://user-images.githubusercontent.com/9192164/40968488-f4e53682-68b5-11e8-854b-13e6897437af.png)
I fixed it by greping content.

Also, i added option to display newest bookmarks on the top ( disabled by default ) and notifications through libnotify when opening or copying urls.