### PR TITLE
Add multiple display types

### DIFF
--- a/buku_run
+++ b/buku_run
@@ -4,6 +4,10 @@ _rofi () {
     rofi -dmenu -i -no-levenshtein-sort -width 1000 "$@"
 }
 
+# display settings
+display_type=1
+max_str_width=80
+
 # keybindings
 switch_view="Alt+Tab"
 new_bookmark="Alt+n"
@@ -43,7 +47,7 @@ main () {
     HELP="Welcome to Buku. Use <span color='${help_color}'>${new_bookmark}</span> to add a new Bookmark
 Use <span color='${help_color}'>${switch_view}</span> to switch View. <span color='${help_color}'>${actions}</span> for actions"
     if [[ $mode == "bookmarks" ]]; then
-        content=$(buku -p -f 2 | awk 'NF == 2 { $0 = $0 "NOTAG" }; { $2 = substr($2,0,80); print $1"\t"$2"\t"$3,$4,$5 }' | column -t -s $'\t')
+        content=$(parseBuku)
         menu=$(echo "${content}" | _rofi -p '> ' -filter "${filter}" -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
     elif [[ $mode == "tags" ]]; then
         menu=$(buku --np --st | awk '{$NF=""; print $0}' | cut -d ' ' -f2-  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
@@ -69,7 +73,7 @@ Use <span color='${help_color}'>${switch_view}</span> to switch View. <span colo
         fi
     elif [[ $val -eq 0 ]]; then
         if [[ $mode == "bookmarks" ]]; then
-            id=$(echo "${menu%% *}")
+            id=$(getId "$content" "$menu")
             for bm in ${id}; do
                 buku -o "${bm}"
             done
@@ -136,7 +140,7 @@ optionsMenu () {
 }
 
 deleteMenu () {
-    id=$(echo "${menu}" | awk '{ print $1 }')
+    id=$(getId "$content" "$menu")
     delask=$(echo -e "1. Yes\n2. No" | _rofi -p '> ' -mesg "Really delete bookmark?")
     val=$?
     if [[ $val -eq 1 ]]; then
@@ -152,10 +156,11 @@ deleteMenu () {
 }
 
 editMenu () {
-    bookmark=$(echo "${menu}" | awk '{ print $2 }')
-    id=$(echo "${menu}" | awk '{ print $1 }')
-    tags=$(echo "${menu}" | awk '{ print substr($0, index($0,$3)) }' | sed 's/NOTAG//g')
-    content=$(echo -e "1. url:  $bookmark\n2. tags: $tags")
+    id=$(getId "$content" "$menu")
+    title="$(getTitleFromId $id)"
+    bookmark="$(getUrlFromId $id)"
+    tags="$(getTagsFromId $id)"
+    content=$(echo -e "1. title: $title\n2. url: $bookmark\n3. tags: $tags")
     editmenu=$(echo -e "< Return\n---\n${content}" | _rofi -p '> ')
     val=$?
     if [[ $val -eq 1 ]]; then
@@ -169,6 +174,8 @@ editMenu () {
             tags="${tags}" editTags
         elif [[ $editmenu =~ url:* ]]; then
             editBookmark
+        elif [[ $editmenu =~ title:* ]]; then
+            editTitle
         fi
     fi
 }
@@ -198,6 +205,17 @@ editBookmark () {
         fi
     fi
     mode=bookmarks main
+}
+
+editTitle () {
+  titlemenu=$(echo "" | _rofi -p "> " -filter "${title}" -mesg "Edit Title and hit Enter")
+  val=$?
+  if [[ $val -eq 1 ]]; then
+    exit
+  elif [[ $val -eq 0 ]]; then
+    buku -u "${id}" --title "${titlemenu}"
+  fi
+  mode=bookmarks main
 }
 
 addMark () {
@@ -232,4 +250,83 @@ addTags () {
         fi
     fi
 }
+
+parseBuku () {
+  echo "$(buku --nc -p | gawk -v max="$max_str_width" -v type="$display_type" '
+BEGIN {
+  RS=""
+  FS="\n"
+}
+{
+  if ($3 == "")
+    $3 = " # NOTAG"
+  id = gensub(/([0-9]+)\.(.*)/, "\\1", "g", $1)
+  url = substr(gensub(/\s+> (.*)/, "\\1", "g", $2),0,max)
+  tags = gensub(/\s+# (.*)/, "\\1", "g", $3)
+  title = substr(gensub(/[0-9]+\.\s*(.*)/, "\\1", "g", $1),0,max)
+
+  if (type == 1)
+    print id "\t" url "\t" tags
+  else
+    print id "\t" title "\t" tags
+    if (type == 3)
+      print " \t" url "\t "
+  print ""
+}
+' | column -t -s $'\t')"
+}
+
+getId () {
+  id=$(echo "${2%% *}")
+  if [ -z "$id" ]; then
+    prev=""
+    IFS=$'\n'
+    for line in $1; do
+      if [ "$2" = "$line" ]; then
+        id=$(echo "${prev%% *}")
+        break
+      else
+        prev="$line"
+      fi
+    done
+  fi
+  echo $id
+}
+
+getTitleFromId () {
+  echo "$(buku --nc -p $1 | gawk '
+  BEGIN {
+    RS=""
+    FS="\n"
+  }
+  {
+    print gensub(/[0-9]+\.\s*(.*)/, "\\1", "g", $1)
+  }
+  ')"
+}
+
+getUrlFromId () {
+  echo "$(buku --nc -p $1 | gawk '
+  BEGIN {
+    RS=""
+    FS="\n"
+  }
+  {
+    print gensub(/\s+> (.*)/, "\\1", "g", $2)
+  }
+  ')"
+}
+
+getTagsFromId () {
+  echo "$(buku --nc -p $1 | gawk '
+  BEGIN {
+    RS=""
+    FS="\n"
+  }
+  {
+    print gensub(/\s+# (.*)/, "\\1", "g", $3)
+  }
+  ')"
+}
+
 mode=bookmarks main

--- a/config.buku
+++ b/config.buku
@@ -4,6 +4,10 @@ _rofi () {
     rofi -dmenu -i -no-levenshtein-sort -width 1000 "$@"
 }
 
+# display settings
+display_type=1
+max_str_width=80
+
 # keybindings
 switch_view="Alt+Tab"
 new_bookmark="Alt+n"


### PR DESCRIPTION
Added the display_type config variable that allows switching between three display types: index-url-tags (default), index-title-tags, index-title-tags plus the url on the next line (inspired by #22).
Regardless of display type, the url and tags are always editable. Added the ability to edit the title of the bookmark.
Added the max_str_width that controls how long titles and urls can be (default 80).

All that's missing is explaining which display type corresponds to which number, unsure whether you prefer that to be on the config file or the readme (or both).